### PR TITLE
fix: delete session copy + stopwatch display

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -294,7 +294,7 @@ const de: Translations = {
   deleteSession: "Session löschen",
   deleteSessionConfirm: "Session löschen?",
   deleteSessionDesc:
-    "Dies löscht die Session und alle zugehörigen Athleten und Ergebnisse unwiderruflich.",
+    "Dies löscht die Session und alle zugehörigen Ergebnisse unwiderruflich. Athleten bleiben im Kader erhalten.",
   // Session page
   childrenTab: "Athleten",
   resultsTab: "Ergebnisse",
@@ -591,7 +591,7 @@ const en: Translations = {
   deleteSession: "Delete session",
   deleteSessionConfirm: "Delete session?",
   deleteSessionDesc:
-    "This will permanently delete the session and all associated athletes and results.",
+    "This will permanently delete the session and all associated results. Athletes will remain in the roster.",
   // Session page
   childrenTab: "Athletes",
   resultsTab: "Results",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -26,11 +26,18 @@ export function formatStopwatch(elapsedMs: number): string {
   const minutes = Math.floor((totalSeconds % 3600) / 60);
   const seconds = totalSeconds % 60;
   const ms = Math.floor((elapsedMs % 1000) / 10);
-  const hh = String(hours).padStart(2, "0");
-  const mm = String(minutes).padStart(2, "0");
   const ss = String(seconds).padStart(2, "0");
   const msStr = String(ms).padStart(2, "0");
-  return `${hh}:${mm}:${ss}.${msStr}`;
+  if (hours > 0) {
+    const hh = String(hours).padStart(2, "0");
+    const mm = String(minutes).padStart(2, "0");
+    return `${hh}:${mm}:${ss}.${msStr}`;
+  }
+  if (minutes > 0) {
+    const mm = String(minutes).padStart(2, "0");
+    return `${mm}:${ss}.${msStr}`;
+  }
+  return `${ss}.${msStr}`;
 }
 
 export function formatCount(n: number): string {


### PR DESCRIPTION
## Summary
- **#14**: Fixed delete session confirmation dialog copy (EN + DE) — removed incorrect claim that athletes are deleted. Athletes are global and remain in the roster; only results are deleted with the session.
- **#23**: Fixed stopwatch format in RacePage — hours are hidden when 0, minutes are hidden when both hours and minutes are 0. Short sprints now show `07.83` instead of `00:00:07.83`.

Closes #14, closes #23

## Test plan
- [ ] Open a session card, click delete, verify the confirmation text no longer mentions athletes being deleted (check both EN and DE locales)
- [ ] Start a timed race for a short sprint (e.g. 60m), verify the stopwatch shows seconds.ms format without leading zeros for hours/minutes
- [ ] Start a longer race, verify minutes and hours appear when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)