### PR TITLE
fix: field event entry UX + attempt limit

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -92,6 +92,9 @@ export function getDisciplinesByCategory(
   return Object.entries(DISCIPLINES).filter(([, c]) => c.category === cat);
 }
 
+/** Maximum number of attempts per athlete in field events (e.g. high jump may need 6+). */
+export const MAX_FIELD_ATTEMPTS = 6;
+
 /** Returns true when the discipline belongs to the "games" category. */
 export function isGamesDiscipline(discipline: string): boolean {
   return DISCIPLINES[discipline]?.category === "games";

--- a/src/pages/RacePage.tsx
+++ b/src/pages/RacePage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useSessionStore } from "@/store/session-store";
-import { DISCIPLINES, isTimedDiscipline, getMedalStyle } from "@/lib/constants";
+import { DISCIPLINES, isTimedDiscipline, getMedalStyle, MAX_FIELD_ATTEMPTS } from "@/lib/constants";
 import { formatTime, formatStopwatch, cn, getAgeGroup } from "@/lib/utils";
 import { GenderBadgeInline } from "@/components/GenderBadge";
 import { AthleteAvatar } from "@/components/ui/athlete-avatar";
@@ -108,7 +108,7 @@ export default function RacePage() {
   const [showGo, setShowGo] = useState(false);
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Field-entry state: attempts per athlete (up to 3)
+  // Field-entry state: attempts per athlete (up to MAX_FIELD_ATTEMPTS)
   interface Attempt {
     value: string; // raw input string
     foul: boolean;
@@ -449,7 +449,7 @@ export default function RacePage() {
           disabled={selectedChildren.length === 0}
           onClick={handleStart}
         >
-          {t.start}
+          {disciplineConfig.mode === "distance" ? t.fieldEntry : t.start}
         </Button>
       </div>
     );
@@ -551,7 +551,7 @@ export default function RacePage() {
     function addAttempt(athleteId: string) {
       setFieldAttempts((prev) => {
         const attempts = prev[athleteId] ?? [];
-        if (attempts.length >= 3) return prev;
+        if (attempts.length >= MAX_FIELD_ATTEMPTS) return prev;
         return { ...prev, [athleteId]: [...attempts, { value: "", foul: false }] };
       });
     }
@@ -669,7 +669,7 @@ export default function RacePage() {
                   ))}
                 </div>
 
-                {attempts.length < 3 && (
+                {attempts.length < MAX_FIELD_ATTEMPTS && (
                   <Button
                     size="sm"
                     variant="ghost"


### PR DESCRIPTION
## Summary
- **#15**: Show "Enter results" button instead of "Start" for distance-mode disciplines (jumping, throwing) on the setup screen, so users can discover field event entry mode
- **#22**: Raise field event attempt limit from 3 to 6 via a configurable `MAX_FIELD_ATTEMPTS` constant in `constants.ts`

Closes #15, closes #22

## Test plan
- [ ] Open a field event discipline (e.g. long jump, high jump) and verify the setup screen shows "Enter results" button
- [ ] Open a timed discipline (e.g. sprint) and verify the setup screen still shows "Start" button
- [ ] In field entry mode, verify athletes can add up to 6 attempts
- [ ] Verify `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)