### PR TITLE
fix: orphan heats cleanup + session-year age groups

### DIFF
--- a/src/components/AgeGroupBadge.tsx
+++ b/src/components/AgeGroupBadge.tsx
@@ -1,10 +1,10 @@
 import { getAgeGroup } from "@/lib/utils";
 
-export function AgeGroupBadge({ yearOfBirth }: { yearOfBirth?: number }) {
+export function AgeGroupBadge({ yearOfBirth, referenceYear }: { yearOfBirth?: number; referenceYear?: number }) {
   if (!yearOfBirth) return null;
   return (
     <span className="rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-semibold text-muted-foreground">
-      {getAgeGroup(yearOfBirth)}
+      {getAgeGroup(yearOfBirth, referenceYear)}
     </span>
   );
 }

--- a/src/hooks/useLeaderboard.ts
+++ b/src/hooks/useLeaderboard.ts
@@ -49,6 +49,7 @@ export function computeLeaderboard(
   const config = DISCIPLINES[discipline];
   if (!config) return { entries: [], hasYobData: false };
 
+  const sessionYear = new Date(session.date).getFullYear();
   const sessionAthletes = athletes.filter((a) => session.athleteIds.includes(a.id));
   const hasYobData = sessionAthletes.some((a) => a.yearOfBirth != null);
 
@@ -56,7 +57,7 @@ export function computeLeaderboard(
   for (const athlete of sessionAthletes) {
     if (ageGroupFilter === "All") {
       allowedAthleteIds.add(athlete.id);
-    } else if (athlete.yearOfBirth != null && getAgeGroup(athlete.yearOfBirth) === ageGroupFilter) {
+    } else if (athlete.yearOfBirth != null && getAgeGroup(athlete.yearOfBirth, sessionYear) === ageGroupFilter) {
       allowedAthleteIds.add(athlete.id);
     }
   }
@@ -118,6 +119,7 @@ export function useLeaderboard(
     const config = DISCIPLINES[discipline];
     if (!config) return { entries: [], hasYobData: false };
 
+    const sessionYear = new Date(session.date).getFullYear();
     const sessionAthletes = athletes.filter((a) => session.athleteIds.includes(a.id));
     const hasYobData = sessionAthletes.some((a) => a.yearOfBirth != null);
     const athleteIdSet = new Set(athletes.map((a) => a.id));
@@ -126,7 +128,7 @@ export function useLeaderboard(
     for (const athlete of sessionAthletes) {
       if (ageGroupFilter === "All") {
         allowedAthleteIds.add(athlete.id);
-      } else if (athlete.yearOfBirth != null && getAgeGroup(athlete.yearOfBirth) === ageGroupFilter) {
+      } else if (athlete.yearOfBirth != null && getAgeGroup(athlete.yearOfBirth, sessionYear) === ageGroupFilter) {
         allowedAthleteIds.add(athlete.id);
       }
     }

--- a/src/lib/pdfExport.ts
+++ b/src/lib/pdfExport.ts
@@ -118,7 +118,7 @@ export function exportSessionPdf(
         athleteId,
         name: athlete?.name ?? athleteId,
         ageGroup: athlete?.yearOfBirth
-          ? getAgeGroup(athlete.yearOfBirth)
+          ? getAgeGroup(athlete.yearOfBirth, new Date(session.date).getFullYear())
           : "",
         result: best ? formatValue(best.value, best.unit) : "—",
         heat: heatLabel,

--- a/src/pages/LeaderboardPage.tsx
+++ b/src/pages/LeaderboardPage.tsx
@@ -240,7 +240,7 @@ export default function LeaderboardPage() {
                         >
                           {entry.athlete?.name ?? entry.athleteId}
                         </span>
-                        <AgeGroupBadge yearOfBirth={entry.athlete?.yearOfBirth} />
+                        <AgeGroupBadge yearOfBirth={entry.athlete?.yearOfBirth} referenceYear={new Date(session.date).getFullYear()} />
                       </div>
 
                       {/* Best value */}

--- a/src/pages/RacePage.tsx
+++ b/src/pages/RacePage.tsx
@@ -345,6 +345,14 @@ export default function RacePage() {
   }
 
   function handleReset() {
+    // Clean up orphan heat (zero results) on repeat/abort (#13)
+    if (id && heatId) {
+      const s = useSessionStore.getState().sessions.find((sess) => sess.id === id);
+      const heat = s?.heats.find((h) => h.id === heatId);
+      if (heat && heat.results.length === 0) {
+        useSessionStore.getState().deleteHeat(id, heatId);
+      }
+    }
     setPhase("setup");
     setStartTime(null);
     setFinishTimes({});
@@ -407,7 +415,7 @@ export default function RacePage() {
                     <span className="flex items-center gap-1">
                       {athlete.yearOfBirth && (
                         <span className="text-[10px] font-normal opacity-70">
-                          {getAgeGroup(athlete.yearOfBirth)}
+                          {getAgeGroup(athlete.yearOfBirth, new Date(session.date).getFullYear())}
                         </span>
                       )}
                       <GenderBadgeInline gender={athlete.gender} />
@@ -752,7 +760,7 @@ export default function RacePage() {
                     <span className="flex items-center gap-1">
                       {athlete?.yearOfBirth && (
                         <span className="text-xs font-normal opacity-70">
-                          {getAgeGroup(athlete.yearOfBirth)}
+                          {getAgeGroup(athlete.yearOfBirth, new Date(session.date).getFullYear())}
                         </span>
                       )}
                       <GenderBadgeInline gender={athlete?.gender} />

--- a/src/pages/SessionPage.tsx
+++ b/src/pages/SessionPage.tsx
@@ -343,7 +343,7 @@ export default function SessionPage() {
                   >
                     <AthleteAvatar name={athlete.name} avatarBase64={athlete.avatarBase64} size="sm" className="h-5 w-5 text-[8px]" />
                     {athlete.name}
-                    <AgeGroupBadge yearOfBirth={athlete.yearOfBirth} />
+                    <AgeGroupBadge yearOfBirth={athlete.yearOfBirth} referenceYear={new Date(session.date).getFullYear()} />
                     <GenderBadge gender={athlete.gender} />
                   </Link>
                 ))}
@@ -409,7 +409,7 @@ export default function SessionPage() {
                       )}
                     />
                     {a.name}
-                    <AgeGroupBadge yearOfBirth={a.yearOfBirth} />
+                    <AgeGroupBadge yearOfBirth={a.yearOfBirth} referenceYear={new Date(session.date).getFullYear()} />
                   </button>
                 ))}
               </div>
@@ -471,7 +471,7 @@ export default function SessionPage() {
                       )}
                     />
                     {a.name}
-                    <AgeGroupBadge yearOfBirth={a.yearOfBirth} />
+                    <AgeGroupBadge yearOfBirth={a.yearOfBirth} referenceYear={new Date(session.date).getFullYear()} />
                   </button>
                 ))}
               </div>
@@ -620,7 +620,7 @@ export default function SessionPage() {
                           <td className="py-2 pr-4">
                             <span className="inline-flex items-center gap-1.5">
                               {entry.athlete?.name ?? entry.athleteId}
-                              <AgeGroupBadge yearOfBirth={entry.athlete?.yearOfBirth} />
+                              <AgeGroupBadge yearOfBirth={entry.athlete?.yearOfBirth} referenceYear={new Date(session.date).getFullYear()} />
                               <GenderBadge gender={entry.athlete?.gender} />
                               {attempts > 1 && (
                                 <span className="text-[10px] text-muted-foreground">×{attempts}</span>
@@ -668,7 +668,7 @@ export default function SessionPage() {
                           <td className="py-2 pr-4">
                             <span className="inline-flex items-center gap-1.5">
                               {result.athleteName || "—"}
-                              <AgeGroupBadge yearOfBirth={result.yearOfBirth} />
+                              <AgeGroupBadge yearOfBirth={result.yearOfBirth} referenceYear={new Date(session.date).getFullYear()} />
                               <GenderBadge gender={result.gender} />
                             </span>
                           </td>
@@ -799,7 +799,7 @@ export default function SessionPage() {
                                 </div>
                                 <span className="flex-1 text-sm inline-flex items-center gap-1.5 min-w-0">
                                   <span className="truncate font-medium">{row.athlete?.name ?? row.athleteId}</span>
-                                  <AgeGroupBadge yearOfBirth={row.athlete?.yearOfBirth} />
+                                  <AgeGroupBadge yearOfBirth={row.athlete?.yearOfBirth} referenceYear={new Date(session.date).getFullYear()} />
                                   <GenderBadge gender={row.athlete?.gender} />
                                 </span>
                                 <span className="shrink-0 font-mono text-sm tabular-nums">


### PR DESCRIPTION
## Summary
- **#13**: `handleReset()` in RacePage now deletes the current heat from the store if it has zero results, preventing orphan empty heats on Repeat and Abort/discard flows.
- **#24**: All `getAgeGroup()` call sites now pass the session's year (`session.date`) instead of relying on `new Date().getFullYear()`. `AgeGroupBadge` gains an optional `referenceYear` prop. Leaderboard filtering and PDF export also use the session year.

Closes #13, closes #24

## Test plan
- [ ] Start a timed race, finish all athletes, click "Repeat" — verify the previous heat with 0 results is removed from the session's heats
- [ ] Start a race and click "Abort" with no partial results — verify no orphan heat remains
- [ ] Create a session with a past date (e.g. 2023), add athletes with known birth years, and verify age group badges reflect the session year, not the current year
- [ ] Export a session PDF and verify age groups use the session date year
- [ ] `pnpm build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)