### PR TITLE
feat: edit athletes + select all on race setup

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -76,6 +76,7 @@ export interface Translations {
   selectAthletes: string;
   presenceLabel: string;
   noAthletesInSession: string;
+  editAthlete: string;
   selectAll: string;
   deselectAll: string;
   done: string;
@@ -332,6 +333,7 @@ const de: Translations = {
   selectAthletes: "Athleten für Session wählen",
   presenceLabel: "Wer ist dabei?",
   noAthletesInSession: "Keine Athleten ausgewählt. Wähle Athleten aus der globalen Liste.",
+  editAthlete: "Athlet bearbeiten",
   selectAll: "Alle auswählen",
   deselectAll: "Alle abwählen",
   done: "Fertig",
@@ -629,6 +631,7 @@ const en: Translations = {
   selectAthletes: "Select athletes for session",
   presenceLabel: "Who's here?",
   noAthletesInSession: "No athletes selected. Pick athletes from the global roster.",
+  editAthlete: "Edit athlete",
   selectAll: "Select all",
   deselectAll: "Deselect all",
   done: "Done",

--- a/src/pages/AthletesPage.tsx
+++ b/src/pages/AthletesPage.tsx
@@ -22,7 +22,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Trash2, Plus, Users, Camera, X } from "lucide-react";
+import { Trash2, Plus, Users, Camera, X, Pencil } from "lucide-react";
 
 const CURRENT_YEAR = new Date().getFullYear();
 // Ages 3–21 → 19 chips; the 20th slot is a custom entry
@@ -68,6 +68,14 @@ export default function AthletesPage() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const replaceFileInputRef = useRef<HTMLInputElement>(null);
   const [replaceTarget, setReplaceTarget] = useState<string | null>(null);
+
+  // Edit athlete state
+  const [editId, setEditId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editYear, setEditYear] = useState<number | null>(null);
+  const [editGender, setEditGender] = useState<Gender | undefined>(undefined);
+  const [editCustomOpen, setEditCustomOpen] = useState(false);
+  const [editCustomInput, setEditCustomInput] = useState("");
 
   const handleFileSelect = useCallback(async (file: File, athleteId?: string) => {
     try {
@@ -129,6 +137,37 @@ export default function AthletesPage() {
     setRemoveTarget(null);
   }
 
+  function startEdit(athleteId: string) {
+    const athlete = athletes.find((a) => a.id === athleteId);
+    if (!athlete) return;
+    setEditId(athleteId);
+    setEditName(athlete.name);
+    setEditYear(athlete.yearOfBirth ?? null);
+    setEditGender(athlete.gender);
+    setEditCustomOpen(false);
+    setEditCustomInput("");
+  }
+
+  function handleEditSave() {
+    if (!editId || !editName.trim()) return;
+    const athlete = athletes.find((a) => a.id === editId);
+    if (!athlete) return;
+    updateAthlete(editId, editName.trim(), editYear ?? undefined, editGender, athlete.avatarBase64);
+    toast.success(t.athleteUpdated);
+    setEditId(null);
+  }
+
+  function handleEditCustomConfirm() {
+    const parsed = parseInt(editCustomInput, 10);
+    if (parsed > 1900 && parsed <= CURRENT_YEAR) {
+      setEditYear(parsed);
+    }
+    setEditCustomOpen(false);
+    setEditCustomInput("");
+  }
+
+  const isEditCustomYear = editYear !== null && !YEAR_OPTIONS.includes(editYear);
+
   return (
     <div className="space-y-4">
       <h1 className="text-3xl font-bold heading-tight">{t.athletesNav}</h1>
@@ -187,6 +226,15 @@ export default function AthletesPage() {
                     <X className="h-4 w-4" />
                   </Button>
                 )}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 text-muted-foreground"
+                  onClick={() => startEdit(athlete.id)}
+                  aria-label={t.editAthlete}
+                >
+                  <Pencil className="h-4 w-4" />
+                </Button>
                 <Button
                   variant="ghost"
                   size="icon"
@@ -366,6 +414,97 @@ export default function AthletesPage() {
               onClick={() => removeTarget && handleRemove(removeTarget)}
             >
               {t.removeChild}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Edit athlete dialog */}
+      <AlertDialog
+        open={editId !== null}
+        onOpenChange={(open) => !open && setEditId(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t.editAthlete}</AlertDialogTitle>
+            <AlertDialogDescription className="sr-only">{t.editAthlete}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="space-y-3">
+            <Input
+              placeholder={t.childNameLabel}
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleEditSave()}
+            />
+            <div className="grid grid-cols-5 sm:grid-cols-10 gap-1.5">
+              {YEAR_OPTIONS.map((y) => (
+                <button
+                  key={y}
+                  type="button"
+                  onClick={() => { setEditYear(editYear === y ? null : y); setEditCustomOpen(false); }}
+                  className={cn(
+                    "rounded-md border py-1.5 text-xs font-medium tabular-nums transition-colors",
+                    editYear === y
+                      ? "border-accent bg-accent text-accent-foreground"
+                      : "border-border bg-transparent text-muted-foreground hover:border-foreground hover:text-foreground",
+                  )}
+                >
+                  {y}
+                </button>
+              ))}
+              <button
+                type="button"
+                onClick={() => setEditCustomOpen((v) => !v)}
+                className={cn(
+                  "rounded-md border py-1.5 text-xs font-medium transition-colors",
+                  isEditCustomYear || editCustomOpen
+                    ? "border-accent bg-accent text-accent-foreground"
+                    : "border-border bg-transparent text-muted-foreground hover:border-foreground hover:text-foreground",
+                )}
+              >
+                {isEditCustomYear ? editYear : "···"}
+              </button>
+            </div>
+            {editCustomOpen && (
+              <div className="flex gap-2">
+                <Input
+                  autoFocus
+                  type="number"
+                  placeholder="e.g. 1998"
+                  value={editCustomInput}
+                  onChange={(e) => setEditCustomInput(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && handleEditCustomConfirm()}
+                  className="w-32 text-base md:text-sm"
+                />
+                <Button size="sm" onClick={handleEditCustomConfirm}>
+                  {t.done}
+                </Button>
+              </div>
+            )}
+            <div className="flex gap-2">
+              {(["male", "female", "nonbinary"] as const).map((g) => (
+                <button
+                  key={g}
+                  type="button"
+                  onClick={() => setEditGender(editGender === g ? undefined : g)}
+                  aria-label={t.genderLabels[g]}
+                  title={t.genderLabels[g]}
+                  className={cn(
+                    "flex-1 rounded-md border py-2 text-base transition-colors",
+                    editGender === g
+                      ? "border-accent bg-accent text-accent-foreground"
+                      : "border-border bg-transparent text-muted-foreground hover:border-foreground hover:text-foreground",
+                  )}
+                >
+                  {g === "male" ? "♂" : g === "female" ? "♀" : "⚧"}
+                </button>
+              ))}
+            </div>
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t.cancel}</AlertDialogCancel>
+            <AlertDialogAction onClick={handleEditSave}>
+              {t.save}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/pages/RacePage.tsx
+++ b/src/pages/RacePage.tsx
@@ -390,7 +390,24 @@ export default function RacePage() {
         </div>
 
         <div className="space-y-2">
-          <p className="text-sm font-medium">{t.selectParticipants}</p>
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-medium">{t.selectParticipants}</p>
+            {sessionAthletes.length > 0 && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  const allIds = sessionAthletes.map((a) => a.id);
+                  const allSelected = allIds.every((id) => selectedChildren.includes(id));
+                  setSelectedChildren(allSelected ? [] : allIds);
+                }}
+              >
+                {sessionAthletes.every((a) => selectedChildren.includes(a.id))
+                  ? t.deselectAll
+                  : t.selectAll}
+              </Button>
+            )}
+          </div>
           <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
             {sessionAthletes.map((athlete) => {
               const selected = selectedChildren.includes(athlete.id);


### PR DESCRIPTION
## Summary
- **#16 Edit athlete details**: Added a pencil edit button to each athlete row on the Athletes page. Clicking it opens a dialog pre-populated with the athlete's name, birth year, and gender, allowing inline editing via the existing `updateAthlete()` store action. Photo can still be changed via the avatar click.
- **#17 Select All on race setup**: Added a "Select All" / "Deselect All" toggle button to the participant selection area on the race setup screen, so coaches don't have to tap each athlete individually.

Closes #16, closes #17

## Test plan
- [ ] Open Athletes page, click pencil icon on an athlete, verify edit dialog shows pre-filled data
- [ ] Change name/year/gender in edit dialog, save, verify changes persist
- [ ] Open a race setup page with multiple athletes, click "Select all", verify all are selected
- [ ] Click "Deselect all", verify all are deselected
- [ ] Run `pnpm build` — passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)