### PR TITLE
fix: PDF readability, CSV formatting, repeat guard

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -91,6 +91,10 @@ export interface Translations {
   rankCol: string;
   nameCol: string;
   timeCol: string;
+  // Repeat confirmation (#19)
+  repeatConfirmTitle: string;
+  repeatConfirmDesc: string;
+  repeatConfirmAction: string;
   // Disciplines
   disciplines: Record<string, string>;
   // Categories
@@ -344,6 +348,9 @@ const de: Translations = {
   raceFinished: "Rennen beendet!",
   noTimesRecorded: "Keine Zeiten aufgezeichnet.",
   repeat: "Wiederholen",
+  repeatConfirmTitle: "Neuen Lauf starten?",
+  repeatConfirmDesc: "Die aktuellen Ergebnisse wurden gespeichert.",
+  repeatConfirmAction: "Neuen Lauf starten",
   rankCol: "#",
   nameCol: "Name",
   timeCol: "Zeit",
@@ -641,6 +648,9 @@ const en: Translations = {
   raceFinished: "Race finished!",
   noTimesRecorded: "No times recorded.",
   repeat: "Repeat",
+  repeatConfirmTitle: "Start new heat?",
+  repeatConfirmDesc: "The current results have been saved.",
+  repeatConfirmAction: "Start new heat",
   rankCol: "#",
   nameCol: "Name",
   timeCol: "Time",

--- a/src/lib/pdfExport.ts
+++ b/src/lib/pdfExport.ts
@@ -6,6 +6,44 @@ import { getLeaderboardHeatLabel } from "@/lib/i18n";
 import { DISCIPLINES } from "@/lib/constants";
 import { formatValue, getAgeGroup } from "@/lib/utils";
 
+/** Map MDI icon names to simple text/emoji fallbacks for PDF rendering. */
+function iconToText(icon: string): string {
+  const map: Record<string, string> = {
+    "mdi:lightning-bolt": "\u26A1",
+    "mdi:run-fast": "\uD83C\uDFC3",
+    "mdi:run": "\uD83C\uDFC3",
+    "mdi:fence": "\uD83D\uDEA7",
+    "mdi:account-switch": "\uD83D\uDD04",
+    "mdi:timer-sand": "\u23F3",
+    "mdi:heart-pulse": "\u2764",
+    "mdi:swap-horizontal": "\u21C4",
+    "mdi:arrow-right-bold": "\u27A1",
+    "mdi:arrow-up-bold": "\u2B06",
+    "mdi:debug-step-over": "\u2933",
+    "mdi:human-handsup": "\uD83D\uDE4C",
+    "mdi:arrow-up-bold-circle": "\u2B06",
+    "mdi:baseball": "\u26BE",
+    "mdi:circle": "\u26AB",
+    "mdi:baseball-bat": "\uD83C\uDFCF",
+    "mdi:disc": "\uD83D\uDCBF",
+    "mdi:arrow-top-right": "\u2197",
+    "mdi:rocket-launch": "\uD83D\uDE80",
+    "mdi:soccer": "\u26BD",
+    "mdi:basketball": "\uD83C\uDFC0",
+    "mdi:handball": "\uD83E\uDD3E",
+    "mdi:hockey-sticks": "\uD83C\uDFD2",
+    "mdi:volleyball": "\uD83C\uDFD0",
+    "mdi:bullseye": "\uD83C\uDFAF",
+    "mdi:fire": "\uD83D\uDD25",
+    "mdi:rotate-right": "\uD83D\uDD04",
+    "mdi:flag-variant": "\uD83C\uDFF4",
+    "mdi:link-variant": "\uD83D\uDD17",
+    "mdi:forest": "\uD83C\uDF32",
+    "mdi:pencil-outline": "\u270F",
+  };
+  return map[icon] ?? "\u2022";
+}
+
 /**
  * Generates and downloads a formatted A4 PDF results sheet for a session.
  * Entirely client-side — no network requests.
@@ -129,7 +167,7 @@ export function exportSessionPdf(
     }
   }
 
-  // Sort: group by discipline, within each discipline sort by rank
+  // Group by discipline
   const grouped = new Map<string, RowData[]>();
   for (const row of rows) {
     const existing = grouped.get(row.discipline) ?? [];
@@ -137,30 +175,72 @@ export function exportSessionPdf(
     grouped.set(row.discipline, existing);
   }
 
-  const tableBody: string[][] = [];
-  let rank = 0;
+  // --- Per-discipline tables with section headers ---
+  const footerDrawer = (data: { settings: { margin: { left: number } } }) => {
+    const pageHeight = doc.internal.pageSize.getHeight();
+    doc.setFontSize(8);
+    doc.setTextColor(150);
+    doc.text(
+      `${t.pdfFooter} — ${new Date().toLocaleDateString()}`,
+      data.settings.margin.left,
+      pageHeight - 10,
+    );
+    doc.text(
+      `${doc.getCurrentPageInfo().pageNumber}`,
+      pageWidth - margin,
+      pageHeight - 10,
+      { align: "right" },
+    );
+  };
 
-  for (const [, disciplineRows] of grouped) {
-    // Sort within discipline
+  for (const [disciplineName, disciplineRows] of grouped) {
+    // Find the discipline key for the icon fallback text
+    const dKey = disciplineKeys.find(
+      (k) => disciplineLabel(k) === disciplineName,
+    );
+    const icon = dKey ? (DISCIPLINES[dKey]?.icon ?? "") : "";
+    // Use a text fallback for the icon (e.g. "mdi:lightning-bolt" → "⚡" mapped below)
+    const iconText = icon ? `${iconToText(icon)}  ` : "";
+
+    // Section header
+    const pageHeight = doc.internal.pageSize.getHeight();
+    if (y > pageHeight - 40) {
+      doc.addPage();
+      y = 20;
+    }
+    doc.setFontSize(13);
+    doc.setTextColor(50, 50, 50);
+    doc.setFont("helvetica", "bold");
+    doc.text(`${iconText}${disciplineName}`, margin, y);
+    doc.setFont("helvetica", "normal");
+    // Underline
+    const textWidth = doc.getTextWidth(`${iconText}${disciplineName}`);
+    doc.setDrawColor(200);
+    doc.line(margin, y + 1.5, margin + textWidth, y + 1.5);
+    doc.setTextColor(0);
+    y += 6;
+
+    // Build table body for this discipline
+    const sectionBody: string[][] = [];
+    let sectionRank = 0;
+    let prevValue: number | undefined;
+
     const asc = disciplineRows[0]?.sortAscending ?? true;
     disciplineRows.sort((a, b) =>
       asc ? a.sortValue - b.sortValue : b.sortValue - a.sortValue,
     );
 
-    // Assign ranks (standard competition ranking 1,1,3)
-    rank = 0;
-    let prevValue: number | undefined;
     for (let i = 0; i < disciplineRows.length; i++) {
       const row = disciplineRows[i];
       if (row.result === "—") {
-        tableBody.push(["—", row.name, row.ageGroup, row.result, row.heat]);
+        sectionBody.push(["—", row.name, row.ageGroup, row.result, row.heat]);
       } else {
         if (row.sortValue !== prevValue) {
-          rank = i + 1;
+          sectionRank = i + 1;
         }
         prevValue = row.sortValue;
-        tableBody.push([
-          String(rank),
+        sectionBody.push([
+          String(sectionRank),
           row.name,
           row.ageGroup,
           row.result,
@@ -168,42 +248,30 @@ export function exportSessionPdf(
         ]);
       }
     }
-  }
 
-  // --- Table ---
-  autoTable(doc, {
-    startY: y,
-    head: [
-      [
-        t.pdfRank,
-        t.pdfName,
-        t.pdfAgeGroup,
-        t.pdfResult,
-        t.pdfHeat,
+    autoTable(doc, {
+      startY: y,
+      head: [
+        [
+          t.pdfRank,
+          t.pdfName,
+          t.pdfAgeGroup,
+          t.pdfResult,
+          t.pdfHeat,
+        ],
       ],
-    ],
-    body: tableBody,
-    margin: { left: margin, right: margin },
-    styles: { fontSize: 10, cellPadding: 3 },
-    headStyles: { fillColor: [50, 50, 50] },
-    didDrawPage: (data) => {
-      // Footer on every page
-      const pageHeight = doc.internal.pageSize.getHeight();
-      doc.setFontSize(8);
-      doc.setTextColor(150);
-      doc.text(
-        `${t.pdfFooter} — ${new Date().toLocaleDateString()}`,
-        data.settings.margin.left,
-        pageHeight - 10,
-      );
-      doc.text(
-        `${doc.getCurrentPageInfo().pageNumber}`,
-        pageWidth - margin,
-        pageHeight - 10,
-        { align: "right" },
-      );
-    },
-  });
+      body: sectionBody,
+      margin: { left: margin, right: margin },
+      styles: { fontSize: 10, cellPadding: 3 },
+      headStyles: { fillColor: [50, 50, 50] },
+      didDrawPage: footerDrawer,
+    });
+
+    // Update y for next section
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const finalY = (doc as any).lastAutoTable?.finalY as number | undefined;
+    y = (finalY ?? y) + 10;
+  }
 
   // --- Download ---
   const sanitized = session.name

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from "react";
 import { toast } from "sonner";
 import { useSessionStore } from "@/store/session-store";
 import type { Session } from "@/store/session-store";
-import { escapeCsvField } from "@/lib/utils";
+import { escapeCsvField, formatValue } from "@/lib/utils";
 import { exportSessionPdf } from "@/lib/pdfExport";
 import { useTranslation } from "@/lib/i18n";
 import { Button } from "@/components/ui/button";
@@ -44,7 +44,7 @@ function exportSessionCsv(
         [
           athleteName(r.athleteId),
           disciplineLabel(h.disciplineType),
-          String(r.value),
+          formatValue(r.value, r.unit),
           r.unit,
           r.recordedAt,
         ].map(escapeCsvField),

--- a/src/pages/RacePage.tsx
+++ b/src/pages/RacePage.tsx
@@ -228,6 +228,7 @@ export default function RacePage() {
   }, [countdownRemaining, startCountdown]);
 
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+  const [repeatDialogOpen, setRepeatDialogOpen] = useState(false);
 
   if (!session || !id) {
     return (
@@ -850,10 +851,28 @@ export default function RacePage() {
         <Button className="flex-1 h-12 text-base rounded-xl" onClick={handleSave}>
           {t.save}
         </Button>
-        <Button variant="outline" className="flex-1 h-12 text-base rounded-xl" onClick={handleReset}>
+        <Button variant="outline" className="flex-1 h-12 text-base rounded-xl" onClick={() => setRepeatDialogOpen(true)}>
           {t.repeat}
         </Button>
       </div>
+
+      {/* Repeat confirmation dialog (#19) */}
+      {repeatDialogOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="mx-4 w-full max-w-sm rounded-2xl border bg-background p-6 space-y-4 shadow-lg">
+            <h2 className="text-lg font-bold">{t.repeatConfirmTitle}</h2>
+            <p className="text-sm text-muted-foreground">{t.repeatConfirmDesc}</p>
+            <div className="flex flex-col gap-2">
+              <Button onClick={() => { setRepeatDialogOpen(false); handleReset(); }}>
+                {t.repeatConfirmAction}
+              </Button>
+              <Button variant="outline" onClick={() => setRepeatDialogOpen(false)}>
+                {t.cancel}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **#18 — PDF discipline headers**: Each discipline now renders with a bold section header (name + icon text fallback) and underline before its results table, making multi-discipline PDFs scannable at a glance
- **#25 — CSV formatted values**: CSV export now uses `formatValue()` to output human-readable values (e.g. "4.56m" instead of raw "456") matching what the UI displays
- **#19 — Repeat confirmation guard**: The "Repeat" button on the finished race screen now shows a confirmation dialog before resetting, preventing accidental result loss

Closes #18, closes #19, closes #25

## Test plan
- [ ] Export a PDF for a session with 3+ disciplines — verify each discipline has a visible header with name and icon
- [ ] Export a CSV for a session with distance results (e.g. long jump) — verify values show as "4.56m" not "456"
- [ ] Finish a timed race, tap "Repeat" — verify confirmation dialog appears before reset
- [ ] Confirm the dialog, verify race resets to setup phase
- [ ] Cancel the dialog, verify race stays on finished screen
- [ ] `pnpm build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)