### PR TITLE
feat: leaderboard UX improvements + post-race navigation

### DIFF
--- a/src/hooks/useLeaderboard.ts
+++ b/src/hooks/useLeaderboard.ts
@@ -45,8 +45,12 @@ export function computeLeaderboard(
   discipline: string,
   athletes: Athlete[],
   ageGroupFilter: AgeGroupFilter = "All",
+  customDisciplineName?: string,
 ): LeaderboardResult {
-  const config = DISCIPLINES[discipline];
+  const isCustom = discipline === "custom";
+  const config = isCustom
+    ? { sortAscending: true, unit: "count" as const, mode: "custom" as const, category: "games" as const, icon: "mdi:star" }
+    : DISCIPLINES[discipline];
   if (!config) return { entries: [], hasYobData: false };
 
   const sessionYear = new Date(session.date).getFullYear();
@@ -65,7 +69,11 @@ export function computeLeaderboard(
   // I1: exclude team- prefixed IDs and IDs not in athletes array
   const athleteIdSet = new Set(athletes.map((a) => a.id));
 
-  const heats = session.heats.filter((h) => h.disciplineType === discipline);
+  const heats = session.heats.filter((h) =>
+    isCustom
+      ? h.disciplineType === "custom" && h.customDisciplineName === customDisciplineName
+      : h.disciplineType === discipline,
+  );
   const bestByAthlete = new Map<string, number>();
 
   for (const heat of heats) {

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -172,6 +172,7 @@ export interface Translations {
   leaderboardGameFilter: string;
   leaderboardAllGames: string;
   leaderboardGameLabel: string;
+  viewLeaderboard: string;
   // Save indicator
   savedAgo: string;
   saveError: string;
@@ -473,6 +474,7 @@ const de: Translations = {
   leaderboardGameFilter: "Spiel",
   leaderboardAllGames: "Alle Spiele",
   leaderboardGameLabel: "Spiel",
+  viewLeaderboard: "Rangliste anzeigen",
   // Save indicator
   savedAgo: "Gespeichert vor {time}",
   saveError: "Speichern fehlgeschlagen",
@@ -774,6 +776,7 @@ const en: Translations = {
   leaderboardGameFilter: "Game",
   leaderboardAllGames: "All games",
   leaderboardGameLabel: "Game",
+  viewLeaderboard: "View Leaderboard",
   // Save indicator
   savedAgo: "Saved {time} ago",
   saveError: "Save failed",

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,10 +1,12 @@
 import { useState, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { useSessionStore } from "@/store/session-store";
 import type { Session } from "@/store/session-store";
 import { escapeCsvField, formatValue } from "@/lib/utils";
 import { exportSessionPdf } from "@/lib/pdfExport";
 import { useTranslation } from "@/lib/i18n";
+import { ROUTES } from "@/routes";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -63,6 +65,7 @@ function exportSessionCsv(
 }
 
 export default function HomePage() {
+  const navigate = useNavigate();
   const rawSessions = useSessionStore((s) => s.sessions);
   const sessions = useMemo(
     () => [...rawSessions].sort((a, b) => b.date.localeCompare(a.date) || b.id.localeCompare(a.id)),
@@ -93,12 +96,13 @@ export default function HomePage() {
 
   function handleCreate() {
     if (!name.trim()) return;
-    addSession(name.trim(), date, selectedAthleteIds);
+    const newId = addSession(name.trim(), date, selectedAthleteIds);
     toast.success(t.sessionCreated);
     setName("");
     setDate(new Date().toISOString().slice(0, 10));
     setSelectedAthleteIds([]);
     setOpen(false);
+    navigate(ROUTES.SESSION(newId));
   }
 
   function handleDelete(id: string) {

--- a/src/pages/LeaderboardPage.tsx
+++ b/src/pages/LeaderboardPage.tsx
@@ -60,25 +60,35 @@ export default function LeaderboardPage() {
     }, { replace: true });
   }, [setSearchParams]);
 
-  // Disciplines with at least one result in this session
+  // Disciplines with at least one result in this session (including custom)
   const availableDisciplines = useMemo(() => {
     if (!session) return [];
-    return [...new Set(session.heats.map((h) => h.disciplineType))].filter(
+    const standard = [...new Set(session.heats.map((h) => h.disciplineType))].filter(
       (d) => d !== "custom" && DISCIPLINES[d],
-    );
+    ).map((d) => ({ discipline: d, customDisciplineName: undefined as string | undefined }));
+    // Collect unique custom discipline names
+    const customNames = [
+      ...new Set(
+        session.heats
+          .filter((h) => h.disciplineType === "custom" && h.customDisciplineName)
+          .map((h) => h.customDisciplineName!),
+      ),
+    ].map((name) => ({ discipline: "custom" as const, customDisciplineName: name }));
+    return [...standard, ...customNames];
   }, [session]);
 
   // Compute leaderboards for every discipline at once
   const sections = useMemo(() => {
     if (!session) return [];
-    return availableDisciplines.map((discipline) => {
+    return availableDisciplines.map(({ discipline, customDisciplineName }) => {
       const { entries, hasYobData } = computeLeaderboard(
         session,
         discipline,
         allAthletes,
         ageGroupFilter,
+        customDisciplineName,
       );
-      return { discipline, entries, hasYobData };
+      return { discipline, customDisciplineName, entries, hasYobData };
     }).filter((s) => s.entries.length > 0);
   }, [session, availableDisciplines, allAthletes, ageGroupFilter]);
 
@@ -92,7 +102,7 @@ export default function LeaderboardPage() {
   }, [session, allAthletes, ageGroupFilter]);
 
   // I6: pass all sections to TV mode for auto-rotation
-  const tvSections = sections.map(({ discipline, entries }) => ({ discipline, entries }));
+  const tvSections = sections.map(({ discipline, customDisciplineName, entries }) => ({ discipline, entries, customDisciplineName }));
 
   if (!session || !id) {
     return (
@@ -167,9 +177,11 @@ export default function LeaderboardPage() {
 
       {/* ── Discipline sections ── */}
       <div className="space-y-4">
-        {sections.map(({ discipline, entries }, sectionIdx) => {
+        {sections.map(({ discipline, customDisciplineName, entries }, sectionIdx) => {
           const config = DISCIPLINES[discipline];
-          const label = t.disciplines[discipline] ?? discipline;
+          const label = discipline === "custom" && customDisciplineName
+            ? customDisciplineName
+            : (t.disciplines[discipline] ?? discipline);
 
           return (
             <div

--- a/src/pages/RacePage.tsx
+++ b/src/pages/RacePage.tsx
@@ -898,6 +898,16 @@ export default function RacePage() {
           </div>
         </div>
       )}
+
+      {id && (
+        <Button
+          variant="ghost"
+          className="w-full h-10 text-sm"
+          onClick={() => navigate(ROUTES.LEADERBOARD(id))}
+        >
+          {t.viewLeaderboard}
+        </Button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **#20**: Include custom disciplines in leaderboard, grouped by `customDisciplineName` with proper labeling and TV mode support
- **#21**: Auto-navigate to the new session page after creation instead of staying on home page
- **#26**: Add "View Leaderboard" button on the finished race screen for direct navigation

Closes #20, closes #21, closes #26

## Test plan
- [ ] Create a session with custom disciplines, verify they appear in leaderboard
- [ ] Create a new session from home page, verify redirect to session page
- [ ] Finish a race, verify "View Leaderboard" button appears and navigates correctly
- [ ] Verify `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)