### PR TITLE
chore: polish repo config and upgrade to Node 24 LTS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    groups:
+      all-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,14 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - uses: pnpm/action-setup@v5
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
-          cache: "pnpm"
+          node-version: 24
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -39,7 +37,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: dist
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,12 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
+      - uses: pnpm/action-setup@v5
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Cache Playwright browsers

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ dist-ssr
 test-results/
 playwright-report/
 blob-report/
+.playwright-mcp/

--- a/package.json
+++ b/package.json
@@ -2,9 +2,13 @@
   "name": "trackly",
   "description": "Coaching tool for youth athletics — track sprints, jumps, throws, and games. Free, offline, no account needed.",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "license": "MIT",
+  "packageManager": "pnpm@10.30.1",
+  "engines": {
+    "node": ">=24"
+  },
   "author": "Lukas Grigis",
   "homepage": "https://lukas-grigis.github.io/trackly/",
   "repository": {


### PR DESCRIPTION
## Summary
- Upgrade Node from 22 to 24 (current LTS) across CI workflows and `engines` field
- Add `packageManager` field to `package.json` for reproducible pnpm installs; remove hardcoded version from CI
- Bump `pnpm/action-setup` v4 → v5, `upload-pages-artifact` v3 → v4
- Group github-actions in dependabot config so updates arrive as a single PR
- Set version to `1.0.0`
- Add `.playwright-mcp/` to `.gitignore`

Also updated repo settings:
- Set homepage to GitHub Pages URL
- Enabled auto-delete branches on merge
- Disabled unused Projects tab
- Added topics: react, typescript, pwa, vite, tailwindcss, youth-athletics, sports-tracking, offline-first

## Test plan
- [ ] CI passes with Node 24
- [ ] Deploy workflow still works with updated actions